### PR TITLE
Mellomrom til overskrift (som var forsvunnet). ny oppdatert: dato

### DIFF
--- a/docs/main.adoc
+++ b/docs/main.adoc
@@ -1,7 +1,7 @@
 include::locale/attributes.adoc[]
 = Veileder for orden i eget hus
 Digitaliseringsdirektoratet
-v2.0, 06.07.2018
+v2.0.1, 13.01.2021
 :description: Veileder for orden i eget hus
 :doctype: book
 :docinfo:
@@ -15,8 +15,11 @@ v2.0, 06.07.2018
 image::digitaliseringsdirektoratet.png[width=50%, pdfwidth=30vw]
 
 Publisert: 2018-06-07
+Oppdatert: 2021-01-13
 
 include::shared/download.adoc[]
+NOTE: *Innmelding av feil og mangler:* +
+Dersom du finner feil eller mangler i dokumentet, ber vi om at dette meldes inn på https://github.com/Informasjonsforvaltning/veileder-orden-i-eget-hus/issues[Github Issues]. Dersom du ikke allerede har bruker på Github kan du opprette bruker gratis.
 
 // Innhold her. Feks ei fil pr kapittel:
 include::1 - målgruppe.adoc[]

--- a/docs/main.adoc
+++ b/docs/main.adoc
@@ -15,7 +15,7 @@ v2.0.1, 13.01.2021
 image::digitaliseringsdirektoratet.png[width=50%, pdfwidth=30vw]
 
 Publisert: 2018-06-07
-Oppdatert: 2021-01-13
+Oppdatert: 2021-01-13 (kun redaksjonelle endringer)
 
 include::shared/download.adoc[]
 NOTE: *Innmelding av feil og mangler:* +


### PR DESCRIPTION
Måtte skynne meg å legge inn mellomrom for å få frem overskriftene igjen. 
Kan ikke pushe kun overskrifter, så gjorde noen endringer i main-fila også. 